### PR TITLE
Fix max_slow_speed setting saving to min_gap

### DIFF
--- a/app-2025.js
+++ b/app-2025.js
@@ -650,7 +650,7 @@ document.getElementById('min_gap').addEventListener("change", function() {
 });
 document.getElementById('max_slow_speed').value = settings.max_slow_speed;
 document.getElementById('max_slow_speed').addEventListener("change", function() { 
-    settings.min_gap = document.getElementById('max_slow_speed').value;
+    settings.max_slow_speed = document.getElementById('max_slow_speed').value;
     saveSettings();
     console.log('max_slow_speed updated');
 });

--- a/app-by-distance.js
+++ b/app-by-distance.js
@@ -861,7 +861,7 @@ document.getElementById('min_gap').addEventListener("change", function() {
 });
 document.getElementById('max_slow_speed').value = settings.max_slow_speed;
 document.getElementById('max_slow_speed').addEventListener("change", function() { 
-    settings.min_gap = document.getElementById('max_slow_speed').value;
+    settings.max_slow_speed = document.getElementById('max_slow_speed').value;
     saveSettings();
     console.log('max_slow_speed updated');
 });

--- a/app.js
+++ b/app.js
@@ -649,7 +649,7 @@ document.getElementById('min_gap').addEventListener("change", function() {
 });
 document.getElementById('max_slow_speed').value = settings.max_slow_speed;
 document.getElementById('max_slow_speed').addEventListener("change", function() { 
-    settings.min_gap = document.getElementById('max_slow_speed').value;
+    settings.max_slow_speed = document.getElementById('max_slow_speed').value;
     saveSettings();
     console.log('max_slow_speed updated');
 });


### PR DESCRIPTION
The change handler for the max slow speed dropdown assigns its value to settings.min_gap instead of settings.max_slow_speed. Two consequences: the slow-speed threshold is never actually saved (it always stays at the default), and changing that dropdown silently overwrites the saved group-gap setting.
Same copy-pasted handler fixed in app.js, app-2025.js and app-by-distance.js.